### PR TITLE
Fix log file location

### DIFF
--- a/reindexer.rb
+++ b/reindexer.rb
@@ -26,6 +26,7 @@ class Reindexer < Formula
 
     inreplace "#{buildpath}/build/cpp_src/cmd/reindexer_server/contrib/config.yml" do |s|
       s.gsub! "/var/lib/reindexer", "#{var}/reindexer"
+      s.gsub! "/var/log/reindexer", "#{var}/log/reindexer"
       s.gsub! "user:", "# user:"
     end
 


### PR DESCRIPTION
It fixes an error on MacOS when starting reindexer_server through brew services:
```
libc++abi.dylib: terminating with uncaught exception of type spdlog::spdlog_ex: Failed opening file /var/log/reindexer/reindexer_server.log for writing: Operation timed out

Signal 6, backtrace:
0  reindexer_server               0x000000010fe07089 sighandler(int) + 66
1  libsystem_platform.dylib       0x00007fff7e70af5a _sigtramp + 26
2  ???                            0x0000000000020008 0x0 + 131080
3  libsystem_c.dylib              0x00007fff7e4a81ae abort + 127
4  libc++abi.dylib                0x00007fff7c3acf8f __cxa_bad_cast + 0
5  libc++abi.dylib                0x00007fff7c3ad113 default_terminate_handler() + 241
6  libobjc.A.dylib                0x00007fff7d7e4eab _objc_terminate() + 105
7  libc++abi.dylib                0x00007fff7c3c87c9 std::__terminate(void (*)()) + 8
8  libc++abi.dylib                0x00007fff7c3c826f __cxxabiv1::exception_cleanup_func(_Unwind_Reason_Code, _Unwind_Exception*) + 0
9  reindexer_server               0x000000010fcc0fd4 spdlog::details::file_helper::open(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, bool) + 394
10  reindexer_server               0x000000010fcc0e11 spdlog::sinks::simple_file_sink<std::__1::mutex>::simple_file_sink(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, bool) + 97
11  reindexer_server               0x000000010fcc0c65 std::__1::shared_ptr<spdlog::sinks::simple_file_sink<std::__1::mutex> > std::__1::shared_ptr<spdlog::sinks::simple_file_sink<std::__1::mutex> >::make_shared<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, bool&>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&&&, bool&&&) + 83
12  reindexer_server               0x000000010fcc0b38 std::__1::shared_ptr<spdlog::logger> spdlog::create<spdlog::sinks::simple_file_sink<std::__1::mutex>, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, bool>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, bool) + 61
13  reindexer_server               0x000000010fcaa770 loggerConfigure() + 776
14  reindexer_server               0x000000010fca99e6 main + 784
15  libdyld.dylib                  0x00007fff7e3fc015 start + 1
```